### PR TITLE
Fix Dhwty/flist-messenger#20

### DIFF
--- a/code/flist_messenger/flist_global.cpp
+++ b/code/flist_messenger/flist_global.cpp
@@ -1,5 +1,6 @@
 #include "flist_global.h"
 #include <QApplication>
+#include <QDesktopWidget>
 #include <QSettings>
 #include <QByteArray>
 #include <iostream>
@@ -96,4 +97,13 @@ QString htmlToPlainText(QString input) {
 	output.replace("&nbsp;", " ");
 	output.replace("&amp;", "&");
 	return output;
+}
+
+void centerOnScreen(QWidget *widge)
+{
+	QRect screen = QApplication::desktop()->availableGeometry(widge);
+	QSize size = widge->size();
+	int x = ((screen.width() - size.width()) / 2) + screen.x();
+	int y = ((screen.height() - size.height()) / 2) + screen.y();
+	widge->setGeometry(x, y, size.width(), size.height());
 }

--- a/code/flist_messenger/flist_global.h
+++ b/code/flist_messenger/flist_global.h
@@ -20,6 +20,10 @@ void fix_broken_escaped_apos (std::string &data);
 QString escapeFileName(QString infilename);
 QString htmlToPlainText(QString input);
 
+// Centre a window on the screen it's mostly on. No idea what happens if
+// the window is not on any screen.
+void centerOnScreen(QWidget *widge);
+
 #define FLIST_VERSIONNUM "0.9.1.dev"
 #define FLIST_VERSION "F-List Messenger [Beta] " FLIST_VERSIONNUM
 #define FLIST_CLIENTID "F-List Desktop Client"

--- a/code/flist_messenger/flist_messenger.cpp
+++ b/code/flist_messenger/flist_messenger.cpp
@@ -290,13 +290,8 @@ void flist_messenger::setupConnectBox()
         this->setCentralWidget ( verticalLayoutWidget );
         connect ( btnConnect, SIGNAL ( clicked() ), this, SLOT ( connectClicked() ) );
 
-				QRect screen = QApplication::desktop()->availableGeometry(this);
-				int wid = screen.width();
-				int hig = screen.height();
-        int mwid = 265;
-        int mhig = 100;
-        setGeometry ( ( wid / 2 ) - ( int ) ( mwid*0.5 ), ( hig / 2 ) - ( int ) ( mhig*0.5 ), mwid, mhig );
-
+				this->resize(265, 100);
+				centerOnScreen(this);
 //        // Fetch version.
 //        lurl = QString ( "https://www.f-list.net/json/getApiTicket.json" );
 //        lreply = qnam.get ( QNetworkRequest ( lurl ) );
@@ -347,12 +342,9 @@ void flist_messenger::setupLoginBox()
         label->setText ( "Character:" );
         setCentralWidget ( groupBox );
         connect ( pushButton, SIGNAL ( clicked() ), this, SLOT ( loginClicked() ) );
-				QRect screen =QApplication::desktop()->availableGeometry(this);
-				int wid = screen.width();
-				int hig = screen.height();
-        int mwid = 265;
-        int mhig = height();
-        setGeometry ( ( wid / 2 ) - ( int ) ( mwid*0.5 ), ( hig / 2 ) - ( int ) ( mhig*0.5 ), mwid, mhig );
+
+				resize(265, height());
+				centerOnScreen(this);
 }
 void flist_messenger::setupSetStatusUI()
 {
@@ -1271,13 +1263,8 @@ void flist_messenger::setupRealUI()
         connect(actionHelp, SIGNAL(triggered()), this, SLOT(helpDialogRequested()));
         connect ( actionAbout, SIGNAL ( triggered() ), this, SLOT ( aboutApp() ) );
         connect ( actionQuit, SIGNAL ( triggered() ), this, SLOT ( quitApp() ) );
-				QRect screen =QApplication::desktop()->availableGeometry(this);
-				int wid = screen.width();
-				int hig = screen.height();
-        int mwid = width();
-        int mhig = height();
-        setGeometry ( ( wid / 2 ) - ( int ) ( mwid*0.5 ), ( hig / 2 ) - ( int ) ( mhig*0.5 ), mwid, mhig );
-        setupConsole();
+				centerOnScreen(this);
+				setupConsole();
 }
 void flist_messenger::setupConsole()
 {


### PR DESCRIPTION
This makes the window centre itself on the monitor it currently occupies rather than the entire desktop. I have no idea what happens if you manage to drag it completely offscreen.
